### PR TITLE
Update Registration module to try to deal with crashed events site.

### DIFF
--- a/www/modules/contrib/registration/README.md
+++ b/www/modules/contrib/registration/README.md
@@ -1,28 +1,7 @@
-# Entity based registration system for Drupal.
+Entity Registration
+===================
 
-## Configuration
-
-1. Download and enable the module.
-2. Create at least one registration bundle (or type) at
-   /admin/structure/registration/registration_types, much like you would a
-   content type.
-3. Add a registration field to any entity you want to enable registrations
-   for. Note the display options: default, link to the registration form,
-   and embedding the actual form.
-4. When you add or edit an entity, select the registration bundle you want to
-   use for.
-5. Registrations are now enabled for the entity and you can configure the
-   registration settings via a local task.
-
-## Settings
-
-1. Enable: Turn registrations on / off for a given node.
-2. Capacity: The maximum number of registrants for a given node. Leave at 0 for
-   no limit.
-3. Allow Multiple: If selected, users can register for more than one slot for
-   this event.
-4. Send a reminder. Checking this exposes reminder date and message template
-   fields.
+An entity-based registration system for Backdrop CMS.
 
 ## Usage / Features
 
@@ -67,10 +46,75 @@ how it works.
 That's it. Now, when a registration is added, users can complete one or more
 field collections for each registrant.
 
-## Roadmap
 
-1. Tighter integration with Field Collection for a more robust registration ->
-   registrant system. Namely, mapping the registration capacity to the number of
-   field collections per registration.
-3. Registration Feature that bundles everything you need in a tidy package to
-   start using registrations out of the box.
+Requirements
+------------
+
+This module requires that the following modules are also enabled:
+
+ * [Entity Plus](https://github.com/backdrop-contrib/entity_plus)
+
+Installation
+------------
+
+- Install this module using the official Backdrop CMS instructions at
+  https://backdropcms.org/guide/modules.
+
+- Visit the configuration page under Administration > Structure > Registration >
+  Types (/admin/structure/registration/registration_types) and create at least
+  one registration type, similar to how you might create a content type.
+
+- Add a registration field to an entity where you would like registration. For
+  example, adda Registration field to an event node type. (Note the display
+  options: default, link to registration form, and embeded registration form.)
+  - Select the registration bundle you created above.
+
+- Registrations are now enabled. Create or edit an entity.
+  - Use the "Manage Registrations" tab to see who's registered, and adjust the
+  registration settings on the "Settings" sub-tab.
+
+
+  ## Settings
+
+  1. Enable:
+     Turn registrations on / off for a given node.
+  2. Capacity:
+     The maximum number of registrants for an entity. Leave at 0 for no limit.
+  3. Allow Multiple:
+     If selected, users can register for more than one slot for this event.
+  4. Send a reminder.
+     Checking this exposes reminder date and message template fields.
+
+Documentation
+-------------
+
+Additional documentation is located in the Wiki:
+https://github.com/backdrop-contrib/registration/wiki/Documentation.
+
+Issues
+------
+
+Bugs and Feature requests should be reported in the Issue Queue:
+https://github.com/backdrop-contrib/registration/issues.
+
+Current Maintainers
+-------------------
+
+- [Joseph Flatt](https://github.com/hosef).
+- [Andy Shillingford](https://github.com/docwilmot).
+- Seeking additional maintainers.
+
+Credits
+-------
+
+- Ported to Backdrop CMS by [Joseph Flatt](https://github.com/hosef).
+- Improved for Backdrop CMS by [Andy Shillingford](https://github.com/docwilmot).
+- Originally written for Drupal by [Lev Tsypin](https://www.drupal.org/u/levelos).
+- Maintained for Drupal by [many generous contributors](https://www.drupal.org/node/1284480/committers)
+
+License
+-------
+
+This project is GPL v2 software.
+See the LICENSE.txt file in this directory for complete text.
+

--- a/www/modules/contrib/registration/includes/registration.forms.inc
+++ b/www/modules/contrib/registration/includes/registration.forms.inc
@@ -187,7 +187,6 @@ function registration_form($form, &$form_state, Registration $registration) {
     $form['#submit'][] = 'registration_send_confirmation';
   }
 
-
   return $form;
 }
 
@@ -480,7 +479,7 @@ function registration_registrations_broadcast_form($form, &$form_state, $entity_
     '#type' => 'textarea',
     '#title' => t('Message'),
     '#description' => t(
-      'Enter the message you want to send to %name registrants. Tokens are supported if the module is enabled, E.g., [node:title].',
+      'Enter the message you want to send to %name registrants. Tokens are supported, E.g., [node:title].',
       array('%name' => entity_label($entity_type, $entity))
     ),
     '#required' => TRUE,
@@ -543,7 +542,6 @@ function registration_broadcast_preview($form, &$form_state) {
   if ($registration_id) {
     $registration = entity_load('registration', $registration_id);
   }
-
   $data = array(
     $entity_type => $entity,
     'registration' => $registration,
@@ -756,7 +754,10 @@ function registration_entity_settings_form($form, &$form_state, $settings, $enti
   // Add token support:
   $form['reminder']['reminder_settings']['token_tree'] = array(
     '#theme' => 'token_tree_link',
-    '#token_types' => array($entity_type, 'registration'),
+    '#token_types' => array(
+      $entity_type,
+      'registration',
+    ),
     '#global_types' => FALSE,
   );
 
@@ -1024,7 +1025,6 @@ function registration_state_form($form, &$form_state, $registration_state, $op =
     '#default_value' => isset($registration_state->show_on_form) ? $registration_state->show_on_form : 0,
   );
 
-  $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save Registration state'),

--- a/www/modules/contrib/registration/lib/registration.entity.inc
+++ b/www/modules/contrib/registration/lib/registration.entity.inc
@@ -23,7 +23,7 @@ class Registration extends Entity {
     $updated;
 
   /**
-   * Specifies the default label, which is picked up by label() by default.
+   * Implements EntityInterface::access().
    */
   public function access($op, $account = NULL) {
     return registration_access($op, $this, $account);
@@ -58,8 +58,7 @@ class Registration extends Entity {
    *   Render array for a registration entity.
    */
   public function buildContent($view_mode = 'full', $langcode = NULL) {
-    // $build = parent::buildContent($view_mode, $langcode);
-    //$build = entity_get_controller('registration')->buildContent($this, $view_mode, $langcode);
+    $build = entity_get_controller('registration')->buildContent($this, $view_mode, $langcode);
     $wrapper = entity_metadata_wrapper('registration', $this);
 
     $host_entity_type_info = entity_get_info($this->entity_type);

--- a/www/modules/contrib/registration/modules/registration_entity_access/registration_entity_access.info
+++ b/www/modules/contrib/registration/modules/registration_entity_access/registration_entity_access.info
@@ -5,3 +5,8 @@ backdrop = 1.x
 type = module
 
 dependencies[] = registration
+
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851

--- a/www/modules/contrib/registration/modules/registration_views/registration_views.info
+++ b/www/modules/contrib/registration/modules/registration_views/registration_views.info
@@ -9,3 +9,8 @@ dependencies[] = views
 
 ; Views: Registration
 ; Views: Registration Host Entity
+
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851

--- a/www/modules/contrib/registration/modules/registration_views/registration_views.module
+++ b/www/modules/contrib/registration/modules/registration_views/registration_views.module
@@ -151,14 +151,6 @@ function registration_views_views_data() {
 }
 
 /**
- * Implements hook_entity_info_alter().
- */
-function registration_views_entity_info_alter(&$entity_info) {
-  // Set our custom Views controller class.
-  $entity_info['registration']['views controller class'] = 'RegistrationViewsController';
-}
-
-/**
  * Implements hook_action_info().
  */
 function registration_views_action_info() {

--- a/www/modules/contrib/registration/modules/registration_views/registration_views.tests.info
+++ b/www/modules/contrib/registration/modules/registration_views/registration_views.tests.info
@@ -1,0 +1,5 @@
+
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851

--- a/www/modules/contrib/registration/modules/registration_waitlist/registration_waitlist.info
+++ b/www/modules/contrib/registration/modules/registration_waitlist/registration_waitlist.info
@@ -6,3 +6,8 @@ type = module
 
 dependencies[] = registration
 
+
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851

--- a/www/modules/contrib/registration/modules/registration_waitlist/registration_waitlist.tests.info
+++ b/www/modules/contrib/registration/modules/registration_waitlist/registration_waitlist.tests.info
@@ -4,3 +4,8 @@ description = Test Registration Wait List module.
 group = Registration
 file = registration_waitlist.test
 
+
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851

--- a/www/modules/contrib/registration/registration.info
+++ b/www/modules/contrib/registration/registration.info
@@ -8,3 +8,8 @@ configure = admin/structure/registration
 dependencies[] = entity
 dependencies[] = entity_plus
 dependencies[] = entity_ui
+
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851

--- a/www/modules/contrib/registration/registration.module
+++ b/www/modules/contrib/registration/registration.module
@@ -39,8 +39,8 @@ function registration_entity_info() {
     'registration' => array(
       'label' => t('Registration'),
       'plural label' => t('Registrations'),
-      'entity class' => 'Registration',
       'controller class' => 'EntityPlusController',
+      'entity class' => 'Registration',
       'metadata controller class' => 'RegistrationMetadataController',
       'base table' => 'registration',
       'fieldable' => TRUE,
@@ -63,6 +63,7 @@ function registration_entity_info() {
       'token type' => 'registration',
       'module' => 'registration',
       'label callback' => 'entity_class_label',
+      'entity cache' => module_exists('entitycache'),
     ),
     'registration_type' => array(
       'label' => t('Registration type'),
@@ -86,6 +87,7 @@ function registration_entity_info() {
         'file path' => backdrop_get_path('module', 'registration') . '/includes',
         'controller class' => 'RegistrationTypeUIController',
       ),
+      'entity cache' => module_exists('entitycache'),
     ),
     'registration_state' => array(
       'label' => t('Registration State'),
@@ -114,15 +116,9 @@ function registration_entity_info() {
       'module' => 'registration',
       'access callback' => 'registration_state_access',
       'exportable' => TRUE,
+      'entity cache' => module_exists('entitycache'),
     ),
   );
-
-  // If the cache table has been created, enable entity caching.
-  if (db_table_exists('cache_entity_registration')) {
-    $entity_info['registration']['entity cache'] = TRUE;
-    $entity_info['registration_type']['entity cache'] = TRUE;
-    $entity_info['registration_state']['entity cache'] = TRUE;
-  }
 
   return $entities;
 }
@@ -1252,7 +1248,6 @@ function registration_send_broadcast($entity_type, $entity_id, $subject, $messag
         $entity_type => $entity,
         'registration' => $registration,
       );
-
       $message = token_replace($message_template, $data, array('clear' => TRUE));
       $params['message'] = $message;
 
@@ -1439,7 +1434,7 @@ function registration_status($entity_type, $entity_id, $reset = FALSE, $spaces =
     // check close date range
     if (isset($close) && ($now >= $close)) {
       $status = FALSE;
-      $errors[] = t('Registration is closed.');
+      $errors[] = t('Registration close date has passed.');
     }
   }
   else {
@@ -1523,7 +1518,6 @@ function registration_token_info() {
     'description' => t('Tokens related to individual Registrations.'),
     'needs-data' => 'registration',
   );
-
   $registration['email'] = array(
     'name' => t('Registration Email'),
     'description' => t('The email address for the person registered.'),
@@ -1539,7 +1533,6 @@ function registration_token_info() {
     'type' => 'user',
   );
 
-
   return array(
     'types' => array('registration' => $type),
     'tokens' => array('registration' => $registration),
@@ -1550,10 +1543,7 @@ function registration_token_info() {
  * Implements hook_tokens().
  */
 function registration_tokens($type, $tokens, array $data = array(), array $options = array()) {
-  $replacements = array();
-
   if ($type == 'registration' && !empty($data['registration'])) {
-
     $registration = $data['registration'];
     $wrapper = entity_metadata_wrapper('registration', $data['registration']);
     $replacements = array();
@@ -1580,6 +1570,7 @@ function registration_tokens($type, $tokens, array $data = array(), array $optio
         $options
       );
     }
+
     if ($entity_tokens = token_find_with_prefix($tokens, 'user')) {
       $entity = $wrapper->user->value();
       $replacements += token_generate(
@@ -1589,9 +1580,9 @@ function registration_tokens($type, $tokens, array $data = array(), array $optio
         $options
       );
     }
-  }
 
-  return $replacements;
+    return $replacements;
+  }
 }
 
 /**
@@ -2062,7 +2053,7 @@ function registration_save(Registration $registration) {
  *
  * @return bool
  *
- * @see registration_entity_access()
+ * @see registration_entity_info()
  */
 function registration_access($op, Registration $registration = NULL, $account = NULL) {
   $account = isset($account) ? $account : $GLOBALS['user'];

--- a/www/modules/contrib/registration/tests/registration.tests.info
+++ b/www/modules/contrib/registration/tests/registration.tests.info
@@ -10,3 +10,8 @@ description = Test hooks provided by Registration.
 group = Registration
 file = registration.test
 
+
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851

--- a/www/modules/contrib/registration/tests/registration_test_api/registration_test_api.info
+++ b/www/modules/contrib/registration/tests/registration_test_api/registration_test_api.info
@@ -6,3 +6,7 @@ type = module
 
 dependencies[] = registration
 hidden = TRUE
+; Added by Backdrop CMS packaging script on 2022-01-20
+project = registration
+version = 1.x-1.2.0
+timestamp = 1642704851


### PR DESCRIPTION
This is an attempt to unwedge the events.b.org site due to out-of-date Registration module. We're updating the current version of the module.